### PR TITLE
docs: add planned implementations for Java in TODO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The examples showcase best practices for integrating Nkwa Pay's payment processi
 - FastAPI implementation
 - Flask implementation
 
+## TODO
+
+### Java
+- Spring Boot implementation (planned)
+- Quarkus implementation (planned)
+
 ## Prerequisites
 
 Before running any example, make sure you have:


### PR DESCRIPTION
This pull request updates the `README.md` file to include a new "TODO" section outlining planned implementations for Java frameworks.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R36): Added a "TODO" section listing planned implementations for Java frameworks, specifically Spring Boot and Quarkus.